### PR TITLE
feat: :sparkles: google oidc example with core api

### DIFF
--- a/packages/core/src/utils/types.ts
+++ b/packages/core/src/utils/types.ts
@@ -1,3 +1,15 @@
 export type Awaitable<T> = T | PromiseLike<T>
 
 export type Nullish = null | undefined | void
+
+export type IsAny<T> = 0 extends 1 & T ? true : false
+
+export type IsFunction<T> = T extends (...args: any[]) => any ? true : false
+
+export type DeepPartial<T> = IsAny<T> extends true
+  ? any
+  : IsFunction<NonNullable<T>> extends true
+  ? T
+  : T extends Record<PropertyKey, any>
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : T


### PR DESCRIPTION
# Summary
Added example of using Google OAuth with the core OIDC API. Also made the core API for OAuth and OIDC more minimal. Integrations should take care of setting options automatically.

# Project
Closes #9 