### PR TITLE
feat: :sparkles: add provider info to response

### DIFF
--- a/packages/core/src/providers/oauth.ts
+++ b/packages/core/src/providers/oauth.ts
@@ -151,6 +151,10 @@ export interface OAuthProviderConfig<T> {
 }
 
 export class OAuthProvider<T = any> implements Handler {
+  static type = 'oauth' as const
+
+  type = OAuthProvider.type
+
   /**
    * The originally provided configuration.
    */
@@ -336,7 +340,13 @@ export class OAuthProvider<T = any> implements Handler {
       }
     }
 
-    return { status: 302, redirect: url.toString(), cookies }
+    return {
+      status: 302,
+      redirect: url.toString(),
+      cookies,
+      providerType: this.type,
+      providerId: this.id,
+    }
   }
 
   public async callback(request: Aponia.Request): Promise<Aponia.Response> {

--- a/packages/core/src/providers/oauth.ts
+++ b/packages/core/src/providers/oauth.ts
@@ -446,6 +446,8 @@ export class OAuthProvider<T = any> implements Handler {
         status: 302,
         cookies,
         redirect: this.pages.redirect,
+        providerType: this.type,
+        providerId: this.id,
       }
 
       return response

--- a/packages/core/src/providers/oidc.ts
+++ b/packages/core/src/providers/oidc.ts
@@ -342,6 +342,8 @@ export class OIDCProvider<T = any> implements Handler {
         status: 302,
         cookies,
         redirect: this.pages.redirect,
+        providerType: this.type,
+        providerId: this.id,
       }
       return response
     } catch (error: any) {

--- a/packages/core/src/providers/oidc.ts
+++ b/packages/core/src/providers/oidc.ts
@@ -55,6 +55,10 @@ export type OIDCProviderConfig<T> = Omit<OAuthProviderConfig<T>, 'endpoints'> &
  * OIDC (OpenID Connect) provider.
  */
 export class OIDCProvider<T = any> implements Handler {
+  static type = 'oidc' as const
+
+  type = OIDCProvider.type
+
   /**
    * The originally provided configuration.
    */
@@ -246,7 +250,13 @@ export class OIDCProvider<T = any> implements Handler {
       })
     }
 
-    return { status: 302, redirect: url.toString(), cookies }
+    return {
+      status: 302,
+      redirect: url.toString(),
+      cookies,
+      providerType: this.type,
+      providerId: this.id,
+    }
   }
 
   public async callback(request: Aponia.Request): Promise<Aponia.Response> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -71,6 +71,16 @@ export interface AponiaResponse {
    * TODO: custom auth pages for displaying payloads.
    */
   body?: unknown
+
+  /**
+   * The type of provider that generated this response (if any).
+   */
+  providerType?: string
+
+  /**
+   * The ID of the provider that generated this response (if any).
+   */
+  providerId?: string
 }
 
 /**


### PR DESCRIPTION
# Summary
- Added `providerType` and `providerId` to the response object.
- OAuth and OIDC providers both append their respective provider info to successful response objects.

# Project
Closes #13